### PR TITLE
support subqueries for parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='redpush',
-    version='0.1',
+    version='0.3',
     py_modules=['cli'],
     include_package_data=True,
     packages=['redpush'],


### PR DESCRIPTION
use the `redpush_id` to match those and if not there, ignore the query